### PR TITLE
Added helper to filter allGuesses.json by round.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,8 @@ import { Navbar } from './components/Navbar';
 import { BottomNav } from './components/BottomNav';
 import { Submitted } from './pages/Submitted';
 
+import { EnglandRoundResults } from './pages/EnglandRoundResults'
+
 import { GuessesProvider } from './context/GuessContext'
 import { MultiRound } from './pages/MultiRound'
 import ScrollToTop from './components/ScrollToTop'
@@ -35,6 +37,10 @@ function App() {
             {/* <Navbar /> */}
             <Toolbar />
             <GuessesProvider>
+              <Routes>
+                {/* TODO test only - update with proper path obvs */}
+                <Route path="/r" element={<EnglandRoundResults />} />
+              </Routes>
               <Locked />
               {/* <Routes>
                 <Route path='/england' element={<EnglandRound />} />

--- a/src/pages/EnglandRoundResults.jsx
+++ b/src/pages/EnglandRoundResults.jsx
@@ -1,0 +1,14 @@
+import allGuesses from '../assets/data/allGuesses.json'
+import { filteredGuessesByRound } from '../utils/helpers'
+
+const engData = filteredGuessesByRound(allGuesses, 'eng')
+
+// just to check it is working
+console.log(engData)
+
+export const EnglandRoundResults = () => {
+
+  return (
+    <div>England Guesses</div>
+  )
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -6,3 +6,23 @@ export const getOptions = (array, labelKey, valueKey) => {
         }
     })
 }
+
+// will work (...?) for each round, not just the England round?
+export const filteredGuessesByRound = (allData, roundPrefix) => {
+    return allData.body.map(object => {
+        return {
+            name: object.name,
+            id: object.id,
+            guesses: filterGuessObject(object.guesses, roundPrefix)
+        }
+    })
+}
+
+const filterGuessObject = (object, prefix) => {
+    return Object.keys(object)
+        .filter(key => key.startsWith(prefix))
+        .reduce((newObject, key) => {
+            newObject[key] = object[key];
+            return newObject;
+        }, {});
+}


### PR DESCRIPTION
![Screenshot 2023-10-12 at 18 03 05](https://github.com/mdnrosen/sillyWC23/assets/109218783/a0cc0da3-ce82-4c95-871f-c88991b623cb)

Title says it all - helper function returns array of objects from `allGuesses.json`, with each object containing a guesses object with only key:values relevant to a specified round.

 See console.log screengrab which demonstrates that it works. Only a very small PR but I though I should at least get some code done today. 

Should be reusable for each round - changing the filter to `multi`, `h2h` and so on...